### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Nayjest/ai-microcore/security/code-scanning/7](https://github.com/Nayjest/ai-microcore/security/code-scanning/7)

In general, the problem is fixed by explicitly declaring a `permissions` block in the workflow (either at the top level or per job) that restricts the `GITHUB_TOKEN` to the minimal permissions needed. For a simple linting workflow that just checks out code and runs pylint, read‑only access to repository contents is sufficient.

The best fix here is to add a `permissions` section at the root of `.github/workflows/pylint.yml`, just below the `name: Pylint` (or just below `on:`) so that it applies to all jobs. Set `contents: read` as CodeQL’s suggested minimal starting point. No other permissions (like `pull-requests`, `issues`, etc.) are needed for this workflow as shown. This change does not impact existing functionality: checkout and linting will continue to work, but the token will no longer have unnecessary write access.

Concretely, in `.github/workflows/pylint.yml` insert:

```yaml
permissions:
  contents: read
```

between the existing `on: [push]` block and the `jobs:` block (or directly after the `name` line, which is also valid), keeping indentation consistent. No imports, methods, or additional definitions are required because this is purely a configuration change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
