### PR TITLE
Update README and GitHub Actions workflow for coverage badge improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@
 name: Tests
 
 permissions:
-  contents: write
+  contents: read
 
 on:
   push:
@@ -17,15 +17,18 @@ jobs:
   build:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -36,25 +39,64 @@ jobs:
       run: |
         pytest --cov=microcore --cov-report=xml
     - name: Generate coverage badge
-      if: matrix.python-version == '3.11' && (
-        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-        )
+      if: matrix.python-version == '3.11' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: |
         pip install genbadge[coverage]
         genbadge coverage -i coverage.xml -o coverage.svg
-    - name: Commit coverage badge
-      if: matrix.python-version == '3.11' && (
-        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-        )
+    - name: Validate coverage badge output
+      if: matrix.python-version == '3.11' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git fetch origin
-        git checkout ${{ github.head_ref || github.ref_name }}
-        git add coverage.svg
-        git commit -m "Update coverage badge [skip ci]" || echo "No changes to commit"
-        git push
+        python3 <<'PY'
+        import os, sys
+        p = "coverage.svg"
+        if not os.path.isfile(p):
+            sys.exit("coverage.svg missing")
+        n = os.path.getsize(p)
+        if n < 120:
+            sys.exit(f"coverage.svg too small ({n} bytes), genbadge likely failed silently")
+        with open(p, "rb") as f:
+            head = f.read(4096)
+        if b"<svg" not in head.lower():
+            sys.exit("coverage.svg does not start with an SVG document")
+        PY
+    - name: Upload coverage badge artifact
+      if: success() && matrix.python-version == '3.11' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-badge
+        path: coverage.svg
+        if-no-files-found: error
+        retention-days: 1
+
+  # Isolated job: no checkout of main, no push from PRs — token write only to publish orphan branch.
+  update-coverage-badge:
+    needs: build
+    if: >-
+      github.event_name == 'push' && github.ref == 'refs/heads/main'
+      && needs.build.result == 'success'
+      && !contains(github.event.head_commit.message, '[skip ci]')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: coverage-badge
+        path: badge
+    - name: Push coverage.svg to orphan branch coverage-badge
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -e
+        gh auth setup-git
+        mkdir -p /tmp/coverage-badge-publish
+        cd /tmp/coverage-badge-publish
+        git init
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+        cp "${GITHUB_WORKSPACE}/badge/coverage.svg" .
+        git add coverage.svg
+        git commit -m "Update coverage badge [skip ci]"
+        git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+        git push -f origin HEAD:coverage-badge

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <a href="https://app.codacy.com/gh/Nayjest/ai-microcore/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade" target="_blank"><img src="https://app.codacy.com/project/badge/Grade/441d03416bc048828c649129530dcbc3" alt="Code Quality"></a>
   <a href="https://github.com/Nayjest/ai-microcore/actions/workflows/pylint.yml" target="_blank"><img src="https://github.com/Nayjest/ai-microcore/actions/workflows/pylint.yml/badge.svg" alt="Pylint"></a>
   <a href="https://github.com/Nayjest/ai-microcore/actions/workflows/tests.yml" target="_blank"><img src="https://github.com/Nayjest/ai-microcore/actions/workflows/tests.yml/badge.svg" alt="Tests"></a>
-  <img src="https://raw.githubusercontent.com/Nayjest/ai-microcore/main/coverage.svg" alt="Code Coverage">
+  <img src="https://raw.githubusercontent.com/Nayjest/ai-microcore/coverage-badge/coverage.svg" alt="Code Coverage">
   <a href="https://github.com/vshymanskyy/StandWithUkraine/blob/main/README.md" target="_blank"><img src="https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/refs/heads/main/badges/StandWithUkraine.svg" alt="Stand With Ukraine"></a>
   <a href="https://github.com/Nayjest/ai-microcore/blob/main/LICENSE" target="_blank"><img src="https://img.shields.io/static/v1?label=license&message=MIT&color=d08aff" alt="License"></a>
 </p>


### PR DESCRIPTION

- Updated the coverage badge URL in README.md to point to the correct path.
- Modified the GitHub Actions workflow to change permissions from write to read for contents.
- Upgraded actions/checkout and actions/setup-python to their latest versions.
- Added validation steps for the coverage badge generation to ensure the output is valid.
- Introduced a new job to upload the coverage badge as an artifact and handle its publishing to an orphan branch.