### PR TITLE
vector_db: support custom document IDs in save/save_many

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,20 @@
 </p>
 
 
-**MicroCore** is a collection of python adapters for Large Language Models
-and Vector Databases / Semantic Search APIs allowing to 
+**MicroCore** is a collection of Python adapters for Large Language Models
+and Vector Databases / Semantic Search APIs allowing you to 
 communicate with these services in a convenient way, make them easily switchable 
 and separate business logic from the implementation details.
 
 It defines interfaces for features typically used in AI applications,
 which allows you to keep your application as simple as possible and try various models & services
-without need to change your application code.
+without the need to change your application code.
 
-You can even switch between text completion and chat completion models only using configuration.
+You can even switch between text completion and chat completion models using only configuration.
 
 Thanks to LLM-agnostic MCP integration,
 **MicroCore** connects MCP tools to any language models easily,
-whether through API providers that do not support MCP, or through inference using pytorch or arbitrary python functions.
+whether through API providers that do not support MCP, or through inference using PyTorch or arbitrary Python functions.
 
 The basic example of usage is as follows:
 
@@ -38,13 +38,13 @@ while user_msg := input('Enter message: '):
 ## 🔗 Links
 
  - [API Reference](https://ai-microcore.github.io/api-reference/)
- - [PyPi Package](https://pypi.org/project/ai-microcore/)
+ - [PyPI Package](https://pypi.org/project/ai-microcore/)
  - [GitHub Repository](https://github.com/Nayjest/ai-microcore)
 
 
 ## 💻 Installation
 
-Install as PyPi package:
+Install as a PyPI package:
 ```
 pip install ai-microcore
 ```
@@ -81,7 +81,7 @@ For the full list of available configuration options, you may also check
 [`microcore/configuration.py`](https://github.com/Nayjest/ai-microcore/blob/main/microcore/configuration.py#L175).
 
 ### Installing vendor-specific packages
-For models working not via OpenAI API, you may need to install additional packages:
+For models that work via APIs other than the OpenAI API, you may need to install additional packages:
 #### Anthropic Claude
 ```bash
 pip install anthropic
@@ -94,7 +94,7 @@ pip install google-genai
 #### Local language models via Hugging Face Transformers
 
 You will need to install transformers and a deep learning library of your choice
-(PyTorch, TensorFlow, Flax, etc).
+(PyTorch, TensorFlow, Flax, etc.).
 
 See [transformers installation](https://huggingface.co/docs/transformers/installation).
 
@@ -156,7 +156,7 @@ In order to use vector database functions with Qdrant, you need to install the `
 ```bash
 pip install qdrant-client
 ```
-Configuration example
+Configuration example:
 ```python
 from microcore import configure, EmbeddingDbType
 from sentence_transformers import SentenceTransformer
@@ -237,14 +237,14 @@ configure(
 )
 ```
 
-### texts.search(collection: str, query: str | list, n_results: int = 5, where: dict = None, **kwargs) → list[str]
+### texts.search(collection: str, query: str | list, n_results: int = 5, where: dict = None, \*\*kwargs) → list[str]
 Similarity search
 
-### texts.find_one(self, collection: str, query: str | list) → str | None
+### texts.find_one(collection: str, query: str | list) → str | None
 Find most similar text
 
-### texts.get_all(self, collection: str) -> list[str]
-Return collection of texts
+### texts.get_all(collection: str) → list[str]
+Return all texts in the collection
 
 ### texts.save(collection: str, text: str, metadata: dict = None, id: str = None)
 Store text and related metadata in embeddings database.
@@ -255,7 +255,7 @@ Store multiple texts and related metadata in the embeddings database.
 Each item may be a string (text), a `(text, metadata)` tuple, or a `(text, metadata, id)` tuple.
 If `id` is not provided, it will be generated.
 
-### texts.clear(collection: str):
+### texts.clear(collection: str)
 Clear collection
 
 ## API providers and models support
@@ -264,14 +264,14 @@ MicroCore supports major API providers via various chat completion / text comple
 
 Tested with the following services:
 - [OpenAI](https://openai.com)
-- [Anthropic](https://anthropic.com)  (via Anthropic API and via OpenAI API)
+- [Anthropic](https://anthropic.com) (via Anthropic API and via OpenAI API)
 - [MistralAI](https://mistral.ai)
 - [Google AI Studio](https://aistudio.google.com/) (via Google GenAI API and via OpenAI API)
 - [Google Vertex AI](https://cloud.google.com/vertex-ai?hl=en)
 - [xAI](https://x.ai/)
 - [Microsoft Azure](https://azure.microsoft.com/en-us/products/ai-services/openai-service)
 - [Perplexity](https://www.perplexity.ai/api-platform)
-- [DeepSeek](https://www.deepseek.ai/)
+- [DeepSeek](https://www.deepseek.com/)
 - [Cohere](https://cohere.com/)
 - [RunPod](https://www.runpod.io/) (via OpenAI API)
 - [Cerebras](https://www.cerebras.ai/)
@@ -287,7 +287,7 @@ Tested with the following services:
 
 And more via Google / Anthropic / OpenAI API.
 
-## Supported local language model APIs:
+## Supported local language model APIs
 - HuggingFace [Transformers](https://huggingface.co/docs/transformers/index) (see configuration examples [here](https://github.com/Nayjest/ai-microcore/blob/main/tests/local/test_transformers.py)).
 - Command-line LLM tools (e.g. [`llm`](https://llm.datasette.io/), [`ollama`](https://ollama.com/), `claude`, `gemini`) via `ApiType.CLI` (see [Inference via a command-line tool](#inference-via-a-command-line-tool-cli)).
 - Custom local models by providing own function for chat / text completion, sync / async inference.
@@ -295,13 +295,13 @@ And more via Google / Anthropic / OpenAI API.
 ## 🖼️ Examples
 
 #### [Code review tool](https://github.com/Nayjest/ai-microcore/blob/main/examples/code-review-tool)
-Performs a code review by LLM for changes in git .patch files in any programming languages.
+Performs a code review by LLM for changes in git .patch files in any programming language.
 
 #### [Image analysis](https://colab.research.google.com/drive/1qTJ51wxCv3VlyqLt3M8OZ7183YXPFpic) (Google Colab)
 Determine the number of petals and the color of the flower from a photo (gpt-4-turbo)
 
 #### [Benchmark LLMs on math problems](https://www.kaggle.com/code/nayjest/gigabenchmark-llm-accuracy-math-problems) (Kaggle Notebook)
-Benchmark accuracy of 20+ state of the art models on solving olympiad math problems. Inferencing local language models via HuggingFace Transformers, parallel inference.
+Benchmark accuracy of 20+ state-of-the-art models on solving olympiad math problems. Inferencing local language models via HuggingFace Transformers, parallel inference.
 
 #### [Generate meme image](https://github.com/Nayjest/ai-microcore/blob/main/examples/generate_meme_image.py)
 Simple example demonstrating image generation using [OpenAI GPT Image](https://platform.openai.com/docs/guides/image-generation?image-generation-model=gpt-image-1) model.

--- a/README.md
+++ b/README.md
@@ -246,11 +246,14 @@ Find most similar text
 ### texts.get_all(self, collection: str) -> list[str]
 Return collection of texts
 
-### texts.save(collection: str, text: str, metadata: dict = None)
-Store text and related metadata in embeddings database
+### texts.save(collection: str, text: str, metadata: dict = None, id: str = None)
+Store text and related metadata in embeddings database.
+If `id` is not provided, it will be generated.
 
-### texts.save_many(collection: str, items: list[tuple[str, dict] | str])
-Store multiple texts and related metadata in the embeddings database
+### texts.save_many(collection: str, items: list[tuple[str, dict] | tuple[str, dict, str] | str])
+Store multiple texts and related metadata in the embeddings database.
+Each item may be a string (text), a `(text, metadata)` tuple, or a `(text, metadata, id)` tuple.
+If `id` is not provided, it will be generated.
 
 ### texts.clear(collection: str):
 Clear collection

--- a/microcore/__init__.py
+++ b/microcore/__init__.py
@@ -130,11 +130,21 @@ class _EmbeddingDBProxy(AbstractEmbeddingDB):
     ) -> list[str | SearchResult] | str | SearchResult | None:
         return env().texts.get(collection, ids, limit, offset, where, **kwargs)
 
-    def save_many(self, collection: str, items: list[tuple[str, dict] | str]):
+    def save_many(
+        self,
+        collection: str,
+        items: list[tuple[str, dict] | tuple[str, dict, str] | str],
+    ):
         return env().texts.save_many(collection, items)
 
-    def save(self, collection: str, text: str, metadata: dict = None):
-        return env().texts.save(collection, text, metadata)
+    def save(
+        self,
+        collection: str,
+        text: str,
+        metadata: dict = None,
+        id: str = None,  # pylint: disable=redefined-builtin
+    ):
+        return env().texts.save(collection, text, metadata, id)
 
     def clear(self, collection: str):
         return env().texts.clear(collection)
@@ -154,6 +164,8 @@ class _EmbeddingDBProxy(AbstractEmbeddingDB):
 
 texts = _EmbeddingDBProxy()
 """Embedding database, see `microcore.embedding_db.AbstractEmbeddingDB`"""
+vector_db = texts
+"""Alias for `texts`"""
 
 
 def mcp_server(name: str) -> mcp.MCPServer:  # noqa, pylint-disable=E0602
@@ -181,6 +193,7 @@ __all__ = [
     "prompt",
     "fmt",
     "texts",
+    "vector_db",
     "configure",
     "min_setup",
     "validate_config",
@@ -233,4 +246,4 @@ __all__ = [
     # "wrappers",
 ]
 
-__version__ = "6.3.0"
+__version__ = "6.4.0"

--- a/microcore/embedding_db/__init__.py
+++ b/microcore/embedding_db/__init__.py
@@ -6,7 +6,6 @@ import tiktoken
 
 from ..utils import ExtendedString
 
-
 INT32_MAX = 2**31 - 1  # 2147483647
 
 

--- a/microcore/embedding_db/__init__.py
+++ b/microcore/embedding_db/__init__.py
@@ -124,13 +124,41 @@ class AbstractEmbeddingDB(ABC):
     def get_all(self, collection: str) -> SearchResults | list[str | SearchResult]:
         """Return all documents in the collection"""
 
-    def save(self, collection: str, text: str, metadata: dict = None):
-        """Save a single document in the collection"""
-        self.save_many(collection, [(text, metadata)])
+    def save(
+        self,
+        collection: str,
+        text: str,
+        metadata: dict = None,
+        id: str = None,  # pylint: disable=redefined-builtin
+    ):
+        """
+        Save a single document in the collection
+
+        Args:
+            collection (str): collection name
+            text (str): document text
+            metadata (dict): document metadata
+            id (str): document identifier; if not provided, it will be generated
+        """
+        self.save_many(collection, [(text, metadata, id)])
 
     @abstractmethod
-    def save_many(self, collection: str, items: list[tuple[str, dict] | str]):
-        """Save multiple documents in the collection"""
+    def save_many(
+        self,
+        collection: str,
+        items: list[tuple[str, dict] | tuple[str, dict, str] | str],
+    ):
+        """
+        Save multiple documents in the collection
+
+        Args:
+            collection (str): collection name
+            items: list of documents;
+                each item may be a string (text),
+                a tuple of (text, metadata),
+                or a tuple of (text, metadata, id).
+                If id is not provided, it will be generated.
+        """
 
     @abstractmethod
     def clear(self, collection: str):

--- a/microcore/embedding_db/chromadb.py
+++ b/microcore/embedding_db/chromadb.py
@@ -77,21 +77,27 @@ class ChromaEmbeddingDB(AbstractEmbeddingDB):
             else SearchResults([])
         )
 
-    def save_many(self, collection: str, items: list[tuple[str, dict] | str]):
+    def save_many(
+        self,
+        collection: str,
+        items: list[tuple[str, dict] | tuple[str, dict, str] | str],
+    ):
         unique = not self.config.EMBEDDING_DB_ALLOW_DUPLICATES
         texts, ids, metadatas = [], [], []
         for i in items:
             if isinstance(i, str):
-                text = i
-                metadata = None
+                text, metadata, item_id = i, None, None
             else:
                 text = i[0]
                 metadata = i[1] or None
-            if unique and text in texts:
-                continue
+                item_id = str(i[2]) if len(i) > 2 and i[2] is not None else None
+            if item_id is None:
+                if unique and text in texts:
+                    continue
+                item_id = str(hash(text)) if unique else str(uuid.uuid4())
             texts.append(text)
             metadatas.append(metadata)
-            ids.append(str(hash(text)) if unique else str(uuid.uuid4()))
+            ids.append(item_id)
         self._get_collection(collection, create=True).upsert(
             documents=texts, ids=ids, metadatas=metadatas
         )

--- a/microcore/embedding_db/qdrant.py
+++ b/microcore/embedding_db/qdrant.py
@@ -144,7 +144,14 @@ class QdrantEmbeddingDB(AbstractEmbeddingDB):
         )
         return self._wrap_results(hits.points)
 
-    def save_many(self, collection: str, items: list[tuple[str, dict] | str]):
+    def save_many(
+        self,
+        collection: str,
+        items: list[tuple[str, dict] | tuple[str, dict, str] | str],
+    ):
+        """
+        Save multiple documents in the collection.
+        """
         if not self.collection_exists(collection):
             self._create_collection(collection)
         point_structs = []
@@ -152,19 +159,20 @@ class QdrantEmbeddingDB(AbstractEmbeddingDB):
         unique = not self.config.EMBEDDING_DB_ALLOW_DUPLICATES
         for i in items:
             if isinstance(i, str):
-                text = i
-                metadata = dict()
+                text, metadata, new_id = i, dict(), None
             else:
                 text = i[0]
                 metadata = i[1] or {}
+                new_id = i[2] if len(i) > 2 and i[2] is not None else None
             metadata["_text"] = text
-            if unique:
-                new_id = str(uuid.UUID(hashlib.md5(text.encode()).hexdigest()))
-                if new_id in ids:
-                    continue
-                ids.add(new_id)
-            else:
-                new_id = str(uuid.uuid4())
+            if new_id is None:
+                if unique:
+                    new_id = str(uuid.UUID(hashlib.md5(text.encode()).hexdigest()))
+                    if new_id in ids:
+                        continue
+                    ids.add(new_id)
+                else:
+                    new_id = str(uuid.uuid4())
             point_structs.append(
                 PointStruct(
                     id=new_id,

--- a/tests/basic/test_ssearch.py
+++ b/tests/basic/test_ssearch.py
@@ -225,6 +225,32 @@ def test_bool_metadata():
     mc.texts.clear("test_bool_metadata")
 
 
+def test_custom_ids():
+    cid = "test_custom_ids"
+    texts.clear(cid)
+    texts.save(cid, "first doc", id="doc-1")
+    texts.save(cid, "second doc", {"field": "value"}, id="doc-2")
+    texts.save_many(
+        cid,
+        [
+            ("third doc", None, "doc-3"),
+            ("fourth doc", {"field": "value4"}),  # id is generated
+            "fifth doc",  # id is generated
+        ],
+    )
+    assert 5 == texts.count(cid)
+    assert "first doc" == texts.get(cid, "doc-1")
+    item = texts.get(cid, "doc-2")
+    assert "second doc" == item
+    assert {"field": "value"} == item.metadata
+    assert "third doc" == texts.get(cid, "doc-3")
+
+    # saving with an existing id overwrites the document
+    texts.save(cid, "updated doc", id="doc-1")
+    assert "updated doc" == texts.get(cid, "doc-1")
+    assert 5 == texts.count(cid)
+
+
 def test_or_filter():
     cid = "test_collection"
     texts.clear(cid)


### PR DESCRIPTION
## API Changes — v6.4.0

**Custom document IDs** are here. The embedding DB now lets you own your keys instead of relying on auto-generated hashes.
    
  - `texts.save(collection, text, metadata=None, id=None)` — new optional `id` param. Same id = overwrite (true upsert).
  - `texts.save_many(...)` — items now accept a 3-tuple `(text, metadata, id)`, alongside the old `str` and `(text, metadata)` forms. Omit the id, and it's generated as before.
  - New alias: `vector_db = texts`. Same engine, friendlier name.
    
Backward-compatible across Chroma and Qdrant