### PR TITLE
Upgrade Anthropic high-end model to Claude Fable 5, suggest default model in interactive setup

### DIFF
--- a/microcore/interactive_setup.py
+++ b/microcore/interactive_setup.py
@@ -7,6 +7,7 @@ from .configuration import (
 from .llm_backends import (
     ApiPlatform,
     ApiType,
+    DEFAULT_MODELS,
     llm_api_base_required,
     llm_api_key_required,
 )
@@ -59,10 +60,14 @@ def prompt_api_key(
 
 def prompt_model_name(
     question: str = "Enter model name:",
+    default: str = None,
 ) -> str:
     """
     Prompt user to enter an LLM model name.
+    If a default is provided, it is suggested and used when the input is empty.
     """
+    if default:
+        return ask(f"{question} [{magenta(default)}] ").strip() or default
     return ask_non_empty(question).strip()
 
 
@@ -193,7 +198,12 @@ def interactive_setup(
                 )
 
         if "MODEL" not in raw_config:
-            raw_config["MODEL"] = prompt_model_name()
+            default_model = (
+                DEFAULT_MODELS.get(ApiPlatform(platform))
+                if platform in ApiPlatform
+                else None
+            )
+            raw_config["MODEL"] = prompt_model_name(default=default_model)
 
     _fill_extras(raw_config, extras)
 

--- a/microcore/llm_backends.py
+++ b/microcore/llm_backends.py
@@ -241,7 +241,7 @@ DEFAULT_PLATFORMS = {
 
 HIGH_END_MODELS: dict[ApiPlatform, str] = {
     ApiPlatform.OPENAI: "gpt-5.5",  # I/O: $5/$30 /M tokens
-    ApiPlatform.ANTHROPIC: "claude-opus-4-8",  # I/O: $5/$25 /M tokens
+    ApiPlatform.ANTHROPIC: "claude-fable-5",  # I/O: $10/$50 /M tokens
     ApiPlatform.GOOGLE_AI_STUDIO: "gemini-2.5-pro",
     ApiPlatform.GOOGLE_VERTEX_AI: "gemini-2.5-pro",
     ApiPlatform.MISTRAL: "mistral-large-latest",
@@ -254,7 +254,7 @@ HIGH_END_MODELS: dict[ApiPlatform, str] = {
 }
 LOW_END_MODELS: dict[ApiPlatform, str] = {
     ApiPlatform.OPENAI: "gpt-5.4-mini",
-    ApiPlatform.ANTHROPIC: "claude-haiku-4-5",
+    ApiPlatform.ANTHROPIC: "claude-haiku-4-5",  # I/O: $1/$5 /M tokens
     ApiPlatform.GOOGLE_AI_STUDIO: "gemini-3.1-flash-lite",  # I/O: $0.25 $1.50 /M tokens
     ApiPlatform.GOOGLE_VERTEX_AI: "gemini-3.1-flash-lite",
     ApiPlatform.XAI: "grok-4-1-fast",  # I/O: $0.20 $0.50 /M tokens
@@ -266,6 +266,7 @@ LOW_END_MODELS: dict[ApiPlatform, str] = {
     ApiPlatform.PERPLEXITY: "sonar",  # I/O: $1/$1 /M tokens
 }
 MID_END_MODELS: dict[ApiPlatform, str] = {
+    ApiPlatform.ANTHROPIC: "claude-opus-4-8",  # I/O: $5/$25 /M tokens
     ApiPlatform.PERPLEXITY: "sonar-pro",  # I/O: $3/$15 /M tokens
     ApiPlatform.GOOGLE_AI_STUDIO: "gemini-3.5-flash",  # I/O: $1.5/$9 /M tokens
     ApiPlatform.GOOGLE_VERTEX_AI: "gemini-3.5-flash",


### PR DESCRIPTION
Closes #147

## Changes

**`microcore/llm_backends.py`**
- `HIGH_END_MODELS`: Anthropic entry updated `claude-opus-4-8` -> `claude-fable-5` with updated pricing comment (`I/O: $10/$50 /M tokens`). Claude Fable 5 is the new Anthropic tier above Opus.
- `MID_END_MODELS`: added `claude-opus-4-8` (`I/O: $5/$25 /M tokens`) so Opus remains available as a mid-tier option.
- `LOW_END_MODELS`: added the missing pricing comment for `claude-haiku-4-5` (`I/O: $1/$5 /M tokens`).

**`microcore/interactive_setup.py`**
- `prompt_model_name()` now accepts an optional `default`; when provided, the prompt suggests it and empty input accepts it.
- The setup flow passes the chosen platform''s entry from `DEFAULT_MODELS`, so selecting Anthropic suggests `claude-fable-5` by default. Platforms without a default keep the previous required free-text prompt.

Since `DEFAULT_MODELS = HIGH_END_MODELS`, configurations with an empty `MODEL` (or the `high-end` preset) on the Anthropic platform now resolve to `claude-fable-5`.

## Verification

- Imports and model resolution verified for both enum and string platform values (`claude-fable-5` / `claude-opus-4-8` / `claude-haiku-4-5`).
- flake8 clean; pylint 10.00/10 on the touched files.