### PR TITLE
feat(cli): pass prompt via stdin when LLM_CLI has no <request> placeholder

### DIFF
--- a/microcore/llm/cli.py
+++ b/microcore/llm/cli.py
@@ -26,7 +26,7 @@ class CommandLineLLMError(BadAIAnswer):
         super().__init__(message, details)
 
 
-def run_streaming(argv: list[str], on_chunk) -> str:
+def run_streaming(argv: list[str], on_chunk, stdin_data: str | None = None) -> str:
     """
     Run the given command line, streaming stdout to ``on_chunk`` as it arrives.
 
@@ -37,6 +37,10 @@ def run_streaming(argv: list[str], on_chunk) -> str:
     Args:
         argv (list[str]): Command line, already split into arguments.
         on_chunk (callable): Called with each line of stdout as it arrives.
+        stdin_data (str | None): If given, written to the process's stdin and
+            the pipe is closed. Used to pass the prompt without putting it on the
+            command line, which avoids OS argument-length limits (notably the
+            Windows ``CreateProcess`` ~32KB limit) for large prompts.
     Returns:
         str: The full stdout once the process completes.
     Raises:
@@ -45,12 +49,27 @@ def run_streaming(argv: list[str], on_chunk) -> str:
     """
     with subprocess.Popen(
         argv,
+        stdin=subprocess.PIPE if stdin_data is not None else None,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         encoding="utf-8",
         errors="replace",
         bufsize=1,  # line-buffered
     ) as proc:
+        # Feed stdin from a thread so a large prompt can't deadlock against the
+        # stdout/stderr read loops by filling the pipe buffer before we read.
+        stdin_thread = None
+        if stdin_data is not None:
+            def _write_stdin():
+                try:
+                    proc.stdin.write(stdin_data)
+                    proc.stdin.close()
+                except (BrokenPipeError, OSError):
+                    pass  # process exited early; stdout/stderr carry the reason
+
+            stdin_thread = threading.Thread(target=_write_stdin)
+            stdin_thread.start()
+
         # Drain stderr in a thread so a full stderr pipe buffer can never deadlock
         # the stdout read loop below.
         stderr_chunks: list[str] = []
@@ -70,6 +89,8 @@ def run_streaming(argv: list[str], on_chunk) -> str:
             on_chunk(line)
 
         stderr_thread.join()  # finish reading stderr before the context closes the pipe
+        if stdin_thread is not None:
+            stdin_thread.join()
         return_code = proc.wait()
 
     output = "".join(chunks).strip()
@@ -126,11 +147,20 @@ class CommandLineClient(BaseAIChatClient):
         # argument the CLI receives. Splitting happens before substitution, so the
         # prompt always stays within a single argv element.
         argv = shlex.split(self.config.LLM_CLI, posix=True)
-        argv = [a.replace(self.PLACEHOLDER, prompt_str) for a in argv]
+        if any(self.PLACEHOLDER in a for a in argv):
+            # Placeholder present: substitute the prompt into the command line.
+            argv = [a.replace(self.PLACEHOLDER, prompt_str) for a in argv]
+            stdin_data = None
+        else:
+            # No placeholder: pass the prompt via stdin. This avoids OS
+            # argument-length limits (notably Windows CreateProcess ~32KB) that
+            # would otherwise truncate or reject large prompts, and works with
+            # CLIs that read the prompt from stdin (e.g. `claude -p`).
+            stdin_data = prompt_str
         resolved = shutil.which(argv[0])
         if resolved:
             argv[0] = resolved
-        return argv, callbacks
+        return argv, callbacks, stdin_data
 
     def generate(
         self,
@@ -140,13 +170,13 @@ class CommandLineClient(BaseAIChatClient):
         """
         Run the command line with the prompt, streaming output to callbacks as it arrives.
         """
-        argv, callbacks = self.prepare_run(prompt, kwargs)
+        argv, callbacks, stdin_data = self.prepare_run(prompt, kwargs)
 
         def on_chunk(text):
             for cb in callbacks:
                 cb(text)
 
-        result = run_streaming(argv, on_chunk)
+        result = run_streaming(argv, on_chunk, stdin_data)
         return LLMResponse(
             result,
             api_type=ApiType.CLI,
@@ -173,7 +203,7 @@ class AsyncCommandLineClient(BaseAsyncAIClient):
         **kwargs
     ) -> LLMResponse:
         """Run the command line with the prompt, streaming output to callbacks as it arrives."""
-        argv, callbacks = self.sync_client.prepare_run(prompt, kwargs)
+        argv, callbacks, stdin_data = self.sync_client.prepare_run(prompt, kwargs)
         loop = asyncio.get_running_loop()
 
         def on_chunk(text):
@@ -185,7 +215,7 @@ class AsyncCommandLineClient(BaseAsyncAIClient):
                 else:
                     cb(text)
 
-        result = await asyncio.to_thread(run_streaming, argv, on_chunk)
+        result = await asyncio.to_thread(run_streaming, argv, on_chunk, stdin_data)
         return LLMResponse(
             result,
             api_type=ApiType.CLI,

--- a/tests/basic/test_cli_llm.py
+++ b/tests/basic/test_cli_llm.py
@@ -12,9 +12,11 @@ from microcore.llm.cli import CommandLineLLMError
 
 # A minimal CLI "LLM": echoes the request back, fails on "boom", or - on "stream3" -
 # emits three words one at a time (flushed, with a pause) to exercise streaming.
+# The request comes from argv (when <request> is in LLM_CLI) or, failing that,
+# from stdin (when LLM_CLI has no placeholder).
 PARROT = """\
 import sys, time
-req = sys.argv[1] if len(sys.argv) > 1 else ""
+req = sys.argv[1] if len(sys.argv) > 1 else sys.stdin.read()
 if req == "boom":
     sys.stderr.write("kaboom")
     sys.exit(1)
@@ -42,6 +44,21 @@ def cli_setup(tmp_path):
     yield
 
 
+@pytest.fixture()
+def cli_stdin_setup(tmp_path):
+    parrot = tmp_path / "parrot.py"
+    parrot.write_text(PARROT)
+    # No <request> placeholder -> the prompt is delivered to the process via
+    # stdin instead of the command line.
+    mc.configure(
+        USE_DOT_ENV=False,
+        LLM_API_TYPE=mc.ApiType.CLI,
+        LLM_CLI=f"python {parrot.as_posix()}",
+        MODEL="parrot-cli",
+    )
+    yield
+
+
 def test_cli_llm_sync(cli_setup):
     res = mc.llm("ping")
     assert res == "ping"
@@ -55,6 +72,36 @@ def test_cli_llm_multiword_prompt(cli_setup):
 
 async def test_cli_llm_async(cli_setup):
     assert await mc.allm("pong") == "pong"
+
+
+def test_cli_llm_stdin_sync(cli_stdin_setup):
+    # No <request> placeholder -> the prompt is delivered via stdin.
+    res = mc.llm("ping")
+    assert res == "ping"
+    assert res.api_type == mc.ApiType.CLI
+
+
+def test_cli_llm_stdin_multiword(cli_stdin_setup):
+    assert mc.llm("hello world") == "hello world"
+
+
+def test_cli_llm_stdin_large_prompt(cli_stdin_setup):
+    # The reason stdin delivery exists: a prompt far larger than the OS
+    # command-line limit (Windows CreateProcess ~32KB) must still round-trip
+    # intact. As an argv element this would raise OSError/WinError 206.
+    big = "x" * 200_000
+    assert mc.llm(big) == big
+
+
+async def test_cli_llm_stdin_async(cli_stdin_setup):
+    assert await mc.allm("pong") == "pong"
+
+
+def test_cli_llm_stdin_streaming_callback(cli_stdin_setup):
+    chunks = []
+    res = mc.llm("stream3", callback=chunks.append)
+    assert [c.strip() for c in chunks] == ["alpha", "beta", "gamma"]
+    assert res.split() == ["alpha", "beta", "gamma"]
 
 
 def test_cli_llm_streaming_callback(cli_setup):


### PR DESCRIPTION
## Problem

The CLI backend (`microcore/llm/cli.py`) substitutes the prompt into a single argv element via the `<request>` placeholder. On **Windows**, the total command line passed to `CreateProcess` is capped at ~32 KB, so a large prompt fails with `OSError`/`WinError 206` ("The filename or extension is too long") and the call never reaches the tool. (POSIX `ARG_MAX` is much larger but also finite.)

I hit this driving [Gito](https://github.com/Nayjest/Gito) through the `claude` CLI on Windows: any file whose prompt exceeded ~32 KB was silently skipped with a processing warning.

## Change

When `LLM_CLI` contains **no `<request>` placeholder**, deliver the prompt over the process's **stdin** instead. stdin has no command-line length limit and matches how common CLI LLMs already accept a prompt:

```
LLM_CLI=claude --model claude-sonnet-4-6 -p     # reads prompt from stdin
LLM_CLI=ollama run llama3                        # reads prompt from stdin
```

When the placeholder **is** present, behaviour is unchanged — existing configs are unaffected. The routing is simply: placeholder present → argv substitution (as today); placeholder absent → stdin.

### Details
- `run_streaming`: optional `stdin_data`, written from a dedicated thread so a large prompt can't deadlock against the stdout/stderr read loops by filling the pipe buffer before they're drained.
- `prepare_run`: returns `stdin_data` (set only when the placeholder is absent).
- Both sync and async `generate` callers pass it through.

## Tests

Added stdin coverage alongside the existing argv tests in `tests/basic/test_cli_llm.py` (the parrot now reads argv-or-stdin):
- sync, async, multiword, and streaming-callback over stdin;
- a **200 K-char prompt** that round-trips intact via stdin — as an argv element this raises `WinError 206` on Windows.

All 13 tests pass; `pylint microcore/llm/cli.py` rates 10.00/10; flake8 line length respected. Existing argv behaviour is fully covered and unchanged.