### PR TITLE
Update Anthropic model presets to Claude 5 family (Fable 5, Sonnet 5)

### DIFF
--- a/.env.anthropic.example
+++ b/.env.anthropic.example
@@ -1,9 +1,9 @@
 # === Anthropic configuration example ===
 LLM_API_KEY= # Your Anthropic API key here
 LLM_API_TYPE=anthropic
-# claude-haiku-4-5, claude-sonnet-4-5, claude-opus-4-5
+# claude-haiku-4-5, claude-sonnet-5, claude-opus-4-8, claude-fable-5
 # see https://platform.claude.com/docs/en/about-claude/models/overview
-MODEL=claude-sonnet-4-5
+MODEL=claude-sonnet-5
 
 # Include model thinking (reasoning) wrapped in <think>...</think>
 # in LLM responses and streamed output, default: false

--- a/microcore/__init__.py
+++ b/microcore/__init__.py
@@ -241,4 +241,4 @@ __all__ = [
     # "wrappers",
 ]
 
-__version__ = "6.4.3"
+__version__ = "6.4.4"

--- a/microcore/llm_backends.py
+++ b/microcore/llm_backends.py
@@ -241,7 +241,7 @@ DEFAULT_PLATFORMS = {
 
 HIGH_END_MODELS: dict[ApiPlatform, str] = {
     ApiPlatform.OPENAI: "gpt-5.5",  # I/O: $5/$30 /M tokens
-    ApiPlatform.ANTHROPIC: "claude-opus-4-8",  # I/O: $5/$25 /M tokens
+    ApiPlatform.ANTHROPIC: "claude-fable-5",  # I/O: $10/$50 /M tokens
     ApiPlatform.GOOGLE_AI_STUDIO: "gemini-2.5-pro",
     ApiPlatform.GOOGLE_VERTEX_AI: "gemini-2.5-pro",
     ApiPlatform.MISTRAL: "mistral-large-latest",
@@ -266,7 +266,7 @@ LOW_END_MODELS: dict[ApiPlatform, str] = {
     ApiPlatform.PERPLEXITY: "sonar",  # I/O: $1/$1 /M tokens
 }
 MID_END_MODELS: dict[ApiPlatform, str] = {
-    ApiPlatform.ANTHROPIC: "claude-sonnet-4-6",  # I/O: $3/$15 /M tokens
+    ApiPlatform.ANTHROPIC: "claude-sonnet-5",  # I/O: $3/$15 /M tokens
     ApiPlatform.PERPLEXITY: "sonar-pro",  # I/O: $3/$15 /M tokens
     ApiPlatform.GOOGLE_AI_STUDIO: "gemini-3.5-flash",  # I/O: $1.5/$9 /M tokens
     ApiPlatform.GOOGLE_VERTEX_AI: "gemini-3.5-flash",


### PR DESCRIPTION
Fixes #155

Updates the Anthropic model presets in `microcore/llm_backends.py` to the Claude 5 family:

| Preset | Before | After |
|---|---|---|
| `HIGH_END_MODELS` (= `DEFAULT_MODELS`) | `claude-opus-4-8` ($5/$25 per MTok) | `claude-fable-5` ($10/$50 per MTok) |
| `MID_END_MODELS` | `claude-sonnet-4-6` ($3/$15) | `claude-sonnet-5` ($3/$15; intro $2/$10 through 2026-08-31) |
| `LOW_END_MODELS` | `claude-haiku-4-5` | unchanged |

Also updates the model lineup in `.env.anthropic.example` and bumps the version to 6.4.4.

**Behavioral note:** `DEFAULT_MODELS = HIGH_END_MODELS`, so `LLM_API_TYPE=anthropic` without an explicit `MODEL` now defaults to `claude-fable-5`. Fable 5 rejects explicit `thinking` on/off configs (adaptive only) and sampling params (`temperature`/`top_p`/`top_k`), may return `stop_reason: "refusal"`, and requires 30-day data retention — see #155 for details.

**Verified live:** `configure(LLM_API_TYPE="anthropic")` resolves `MODEL` to `claude-fable-5` and a real completion via `mc.llm()` succeeds; `MODEL="high-end"` / `"low-end"` presets and `MID_END_MODELS` resolve to `claude-fable-5` / `claude-haiku-4-5` / `claude-sonnet-5` respectively. Basic test suite passes (3 pre-existing azure-identity failures unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
