### PR TITLE
Add normalized token usage to streaming LLMResponse across providers

### DIFF
--- a/microcore/__init__.py
+++ b/microcore/__init__.py
@@ -241,4 +241,4 @@ __all__ = [
     # "wrappers",
 ]
 
-__version__ = "6.4.4"
+__version__ = "6.5.0"

--- a/microcore/llm/anthropic.py
+++ b/microcore/llm/anthropic.py
@@ -5,6 +5,8 @@ from anthropic.types import (
     ContentBlockDeltaEvent,
     ContentBlockStartEvent,
     ContentBlockStopEvent,
+    MessageDeltaEvent,
+    MessageStartEvent,
     SignatureDelta,
     ThinkingDelta,
 )
@@ -15,7 +17,7 @@ from ..message_types import Role
 from ..types import LLMAsyncFunctionType, LLMFunctionType
 from ..wrappers.llm_response_wrapper import LLMResponse
 from ..llm_backends import ApiType
-from .shared import prepare_callbacks
+from .shared import attrs_with_normalized_usage, prepare_callbacks, streaming_usage_attrs
 
 THINK_OPEN, THINK_CLOSE = "<think>", "</think>\n"
 PART_SEPARATOR = "\n"
@@ -96,10 +98,28 @@ class _StreamFormatter:
         return out
 
 
+def _update_stream_usage(chunk, usage: dict) -> dict:
+    if isinstance(chunk, MessageStartEvent):
+        msg_usage = chunk.message.usage
+        for key in (
+            "input_tokens",
+            "cache_read_input_tokens",
+            "cache_creation_input_tokens",
+        ):
+            val = getattr(msg_usage, key, None)
+            if val is not None:
+                usage[key] = val
+    elif isinstance(chunk, MessageDeltaEvent):
+        if chunk.usage and chunk.usage.output_tokens is not None:
+            usage["output_tokens"] = chunk.usage.output_tokens
+    return usage
+
+
 async def _a_process_streamed_response(
     response, callbacks: list[callable], show_thinking: bool = False
 ):
     parts: list[str] = []
+    usage: dict = {}
 
     async def send(chunk_text: str):
         parts.append(chunk_text)
@@ -111,17 +131,20 @@ async def _a_process_streamed_response(
 
     formatter = _StreamFormatter(show_thinking)
     async for chunk in response:
+        usage = _update_stream_usage(chunk, usage)
         for piece in formatter.process(chunk):
             await send(piece)
     for piece in formatter.finish():
         await send(piece)
-    return LLMResponse("".join(parts), api_type=ApiType.ANTHROPIC)
+    attrs = streaming_usage_attrs(usage)
+    return LLMResponse("".join(parts), attrs=attrs, api_type=ApiType.ANTHROPIC)
 
 
 def _process_streamed_response(
     response, callbacks: list[callable], show_thinking: bool = False
 ):
     parts: list[str] = []
+    usage: dict = {}
 
     def send(chunk_text: str):
         parts.append(chunk_text)
@@ -129,11 +152,13 @@ def _process_streamed_response(
 
     formatter = _StreamFormatter(show_thinking)
     for chunk in response:
+        usage = _update_stream_usage(chunk, usage)
         for piece in formatter.process(chunk):
             send(piece)
     for piece in formatter.finish():
         send(piece)
-    return LLMResponse("".join(parts), api_type=ApiType.ANTHROPIC)
+    attrs = streaming_usage_attrs(usage)
+    return LLMResponse("".join(parts), attrs=attrs, api_type=ApiType.ANTHROPIC)
 
 
 def _prepare_llm_arguments(config: Config, kwargs: dict):
@@ -155,7 +180,7 @@ def _prepare_llm_arguments(config: Config, kwargs: dict):
             "`temperature` and `top_p` cannot both be specified for this model. "
             "`top_p` parameter will be ignored. "
         )
-    show_thinking = args.pop("show_thinking", config.SHOW_THINKING)
+    show_thinking = args.pop("show_thinking", getattr(config, "SHOW_THINKING", False))
     callbacks = prepare_callbacks(config, args)
     return args, {"callbacks": callbacks, "show_thinking": show_thinking}
 
@@ -228,7 +253,7 @@ def make_llm_functions(config: Config) -> tuple[LLMFunctionType, LLMAsyncFunctio
                 cb(response_text)
         return LLMResponse(
             response_text,
-            response.__dict__,
+            attrs_with_normalized_usage(response.__dict__),
             api_type=ApiType.ANTHROPIC,
             response=response,
         )
@@ -249,7 +274,7 @@ def make_llm_functions(config: Config) -> tuple[LLMFunctionType, LLMAsyncFunctio
             cb(response_text)
         return LLMResponse(
             response_text,
-            response.__dict__,
+            attrs_with_normalized_usage(response.__dict__),
             api_type=ApiType.ANTHROPIC,
             response=response,
         )

--- a/microcore/llm/google_genai.py
+++ b/microcore/llm/google_genai.py
@@ -20,7 +20,13 @@ from ..wrappers.llm_response_wrapper import (
     StoredImageGenerationResponse
 )
 from ..utils import is_image_model
-from .shared import make_image_generation_response, prepare_callbacks
+from .shared import (
+    attrs_with_normalized_usage,
+    make_image_generation_response,
+    normalize_usage,
+    prepare_callbacks,
+    streaming_usage_attrs,
+)
 from ..lm_client import BaseAsyncAIClient, BaseAIChatClient
 from ..images import Image, ImageInterface
 from ..llm_backends import ApiPlatform, ApiType
@@ -217,7 +223,7 @@ class GoogleClient(BaseAIChatClient):
                     return make_image_generation_response(images, ctx.save, response_attrs)
                 return LLMResponse(
                     response.text,
-                    response.__dict__,
+                    _attrs_with_google_usage(response),
                     response=response,
                     api_type=ApiType.GOOGLE
                 )
@@ -263,7 +269,7 @@ class AsyncGoogleClient(BaseAsyncAIClient):
                     return make_image_generation_response(images, ctx.save, response_attrs)
                 return LLMResponse(
                     response.text,
-                    response.__dict__,
+                    _attrs_with_google_usage(response),
                     response=response,
                     api_type=ApiType.GOOGLE
                 )
@@ -345,9 +351,21 @@ def _convert_message_roles(messages: list[dict]):
     return messages
 
 
+def _attrs_with_google_usage(response) -> dict:
+    attrs = dict(response.__dict__) if hasattr(response, "__dict__") else {}
+    if (metadata := getattr(response, "usage_metadata", None)) is not None:
+        attrs["usage"] = metadata
+    return attrs_with_normalized_usage(attrs)
+
+
 async def _a_process_streamed_response(response, callbacks: list[callable]):
     response_text: str = ""
+    usage: dict | None = None
+    last_chunk = None
     async for chunk in response:
+        last_chunk = chunk
+        if chunk_usage := normalize_usage(getattr(chunk, "usage_metadata", None)):
+            usage = chunk_usage
         if text_chunk := chunk.text:
             response_text += text_chunk
             for cb in callbacks:
@@ -355,23 +373,30 @@ async def _a_process_streamed_response(response, callbacks: list[callable]):
                     await cb(text_chunk)
                 else:
                     cb(text_chunk)
+    attrs = streaming_usage_attrs(usage)
     return LLMResponse(
         response_text,
-        vars(response) if hasattr(response, '__dict__') else {},
+        attrs,
         api_type=ApiType.GOOGLE,
-        response=response,
+        response=last_chunk,
     )
 
 
 def _process_streamed_response(response, callbacks: list[callable]):
     response_text: str = ""
+    usage: dict | None = None
+    last_chunk = None
     for chunk in response:
+        last_chunk = chunk
+        if chunk_usage := normalize_usage(getattr(chunk, "usage_metadata", None)):
+            usage = chunk_usage
         if text_chunk := chunk.text:
             response_text += text_chunk
             [cb(text_chunk) for cb in callbacks]
+    attrs = streaming_usage_attrs(usage)
     return LLMResponse(
         response_text,
-        vars(response) if hasattr(response, "__dict__") else {},
-        response=response,
+        attrs,
+        response=last_chunk,
         api_type=ApiType.GOOGLE
     )

--- a/microcore/llm/openai.py
+++ b/microcore/llm/openai.py
@@ -20,7 +20,14 @@ from ..wrappers.llm_response_wrapper import (
     StoredImageGenerationResponse
 )
 from ..utils import is_chat_model, is_image_model
-from .shared import make_image_generation_response, make_remove_hidden_output, prepare_callbacks
+from .shared import (
+    attrs_with_normalized_usage,
+    ensure_stream_include_usage,
+    make_image_generation_response,
+    make_remove_hidden_output,
+    prepare_callbacks,
+    streaming_usage_attrs,
+)
 from ..images import (
     Image,
     FileImage,
@@ -76,7 +83,7 @@ class AsyncOpenAIClient(BaseAsyncAIClient):
                     cb(response_text)
             return LLMResponse(
                 response_text,
-                response.__dict__,
+                attrs_with_normalized_usage(response.__dict__),
                 response=response,
                 api_type=ApiType.OPENAI,
             )
@@ -91,7 +98,7 @@ class AsyncOpenAIClient(BaseAsyncAIClient):
             )
         return LLMResponse(
             response.choices[0].text,
-            response.__dict__,
+            attrs_with_normalized_usage(response.__dict__),
             response=response,
             api_type=ApiType.OPENAI,
         )
@@ -218,7 +225,7 @@ class OpenAIClient(BaseAIChatClient):
             cb(response_text)
         return LLMResponse(
             response_text,
-            response.__dict__,
+            attrs_with_normalized_usage(response.__dict__),
             response=response,
             api_type=ApiType.OPENAI,
         )
@@ -298,7 +305,12 @@ async def _a_process_streamed_response(
     response_text: str = ""
     hiding: bool = False
     need_to_hide = hidden_output_begin and hidden_output_end
+    usage = None
+    last_chunk = None
     async for chunk in response:
+        last_chunk = chunk
+        if (chunk_usage := getattr(chunk, "usage", None)) is not None:
+            usage = chunk_usage
         if text_chunk := _get_chunk_text(chunk, chat_model_used):
             if need_to_hide:
                 if text_chunk == hidden_output_begin:
@@ -316,10 +328,11 @@ async def _a_process_streamed_response(
                     await cb(text_chunk)
                 else:
                     cb(text_chunk)
+    attrs = streaming_usage_attrs(usage)
     return LLMResponse(
         response_text,
-        attrs=response.__dict__,
-        response=response,
+        attrs=attrs,
+        response=last_chunk,
         api_type=ApiType.OPENAI
     )
 
@@ -334,7 +347,12 @@ def _process_streamed_response(
     response_text: str = ""
     is_hiding: bool = False
     need_to_hide = hidden_output_begin and hidden_output_end
+    usage = None
+    last_chunk = None
     for chunk in response:
+        last_chunk = chunk
+        if (chunk_usage := getattr(chunk, "usage", None)) is not None:
+            usage = chunk_usage
         if text_chunk := _get_chunk_text(chunk, chat_model_used):
             if need_to_hide:
                 if text_chunk == hidden_output_begin:
@@ -348,10 +366,11 @@ def _process_streamed_response(
                         continue
             response_text += text_chunk
             [cb(text_chunk) for cb in callbacks]
+    attrs = streaming_usage_attrs(usage)
     return LLMResponse(
         response_text,
-        attrs=response.__dict__,
-        response=response,
+        attrs=attrs,
+        response=last_chunk,
         api_type=ApiType.OPENAI
     )
 
@@ -367,6 +386,8 @@ def _prepare_llm_arguments(config: Config, kwargs: dict):
         ),
     )
     callbacks = prepare_callbacks(config, args)
+    if args.get("stream"):
+        ensure_stream_include_usage(args)
     return args, {"callbacks": callbacks}
 
 

--- a/microcore/llm/shared.py
+++ b/microcore/llm/shared.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any
 
 from ..images import FileImage, Image
 from ..wrappers.llm_response_wrapper import ImageGenerationResponse, StoredImageGenerationResponse
@@ -26,6 +27,87 @@ def prepare_callbacks(config: Config, args, set_stream: bool = True) -> list[cal
         args["stream"] = bool(callbacks)
 
     return callbacks
+
+
+def _usage_field(usage: Any, *keys: str):
+    if isinstance(usage, dict):
+        for key in keys:
+            if key in usage:
+                return usage[key]
+        return None
+    for key in keys:
+        val = getattr(usage, key, None)
+        if val is not None:
+            return val
+    return None
+
+
+def normalize_usage(usage: Any) -> dict | None:
+    """Normalize provider-specific usage to a common dict for downstream logging."""
+    if usage is None:
+        return None
+
+    prompt = _usage_field(
+        usage,
+        "prompt_tokens",
+        "input_tokens",
+        "prompt_token_count",
+    )
+    completion = _usage_field(
+        usage,
+        "completion_tokens",
+        "output_tokens",
+        "candidates_token_count",
+    )
+    total = _usage_field(usage, "total_tokens", "total_token_count")
+    cache_read = _usage_field(usage, "cache_read_input_tokens")
+    cache_creation = _usage_field(usage, "cache_creation_input_tokens")
+
+    if (
+        prompt is None
+        and completion is None
+        and total is None
+        and cache_read is None
+        and cache_creation is None
+    ):
+        return None
+
+    if total is None and (prompt is not None or completion is not None):
+        total = (prompt or 0) + (completion or 0)
+
+    result = {
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": total,
+    }
+    if cache_read is not None:
+        result["cache_read_input_tokens"] = cache_read
+    if cache_creation is not None:
+        result["cache_creation_input_tokens"] = cache_creation
+    return result
+
+
+def streaming_usage_attrs(usage: Any) -> dict:
+    if normalized := normalize_usage(usage):
+        return {"usage": normalized}
+    return {}
+
+
+def attrs_with_normalized_usage(attrs: dict) -> dict:
+    result = dict(attrs)
+    if "usage" in result:
+        if normalized := normalize_usage(result["usage"]):
+            result["usage"] = normalized
+        else:
+            result.pop("usage", None)
+    return result
+
+
+def ensure_stream_include_usage(args: dict) -> None:
+    """OpenAI/Azure emit usage in streaming responses only when requested explicitly."""
+    stream_options = dict(args.get("stream_options") or {})
+    stream_options.setdefault("include_usage", True)
+    args["stream_options"] = stream_options
 
 
 def make_image_generation_response(

--- a/microcore/llm/shared.py
+++ b/microcore/llm/shared.py
@@ -32,7 +32,7 @@ def prepare_callbacks(config: Config, args, set_stream: bool = True) -> list[cal
 def _usage_field(usage: Any, *keys: str):
     if isinstance(usage, dict):
         for key in keys:
-            if key in usage:
+            if usage.get(key) is not None:
                 return usage[key]
         return None
     for key in keys:

--- a/tests/basic/test_llm_usage.py
+++ b/tests/basic/test_llm_usage.py
@@ -46,6 +46,19 @@ def test_normalize_usage():
     assert normalize_usage(None) is None
     assert normalize_usage({}) is None
 
+    assert normalize_usage({"prompt_tokens": None, "input_tokens": 5}) == {
+        "prompt_tokens": 5,
+        "completion_tokens": None,
+        "total_tokens": 5,
+    }
+    assert normalize_usage(
+        SimpleNamespace(prompt_tokens=None, input_tokens=5)
+    ) == {
+        "prompt_tokens": 5,
+        "completion_tokens": None,
+        "total_tokens": 5,
+    }
+
 
 @pytest.mark.parametrize(
     "initial,expected",

--- a/tests/basic/test_llm_usage.py
+++ b/tests/basic/test_llm_usage.py
@@ -1,0 +1,141 @@
+from types import SimpleNamespace
+
+import pytest
+from anthropic.types import Message, MessageDeltaEvent, MessageStartEvent, Usage
+from anthropic.types.message_delta_usage import MessageDeltaUsage
+from anthropic.types.raw_message_delta_event import Delta
+
+from microcore.llm.anthropic import _process_streamed_response, _update_stream_usage
+from microcore.llm.openai import _process_streamed_response as oai_process_streamed_response
+from microcore.llm.shared import (
+    ensure_stream_include_usage,
+    normalize_usage,
+    streaming_usage_attrs,
+)
+
+
+def test_normalize_usage():
+    oai = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    assert normalize_usage(oai) == {
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "total_tokens": 15,
+    }
+
+    anthropic = {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_read_input_tokens": 20,
+        "cache_creation_input_tokens": 5,
+    }
+    assert normalize_usage(anthropic) == {
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "total_tokens": 150,
+        "cache_read_input_tokens": 20,
+        "cache_creation_input_tokens": 5,
+    }
+
+    google = SimpleNamespace(prompt_token_count=7, candidates_token_count=3)
+    assert normalize_usage(google) == {
+        "prompt_tokens": 7,
+        "completion_tokens": 3,
+        "total_tokens": 10,
+    }
+
+    assert normalize_usage(None) is None
+    assert normalize_usage({}) is None
+
+
+@pytest.mark.parametrize(
+    "initial,expected",
+    [
+        ({}, {"include_usage": True}),
+        ({"stream_options": {}}, {"include_usage": True}),
+        ({"stream_options": {"include_usage": False}}, {"include_usage": False}),
+        ({"stream_options": {"foo": 1}}, {"foo": 1, "include_usage": True}),
+    ],
+)
+def test_ensure_stream_include_usage(initial, expected):
+    args = {"stream": True, **initial}
+    ensure_stream_include_usage(args)
+    assert args["stream_options"] == expected
+
+
+def test_streaming_usage_attrs():
+    assert streaming_usage_attrs(None) == {}
+    assert streaming_usage_attrs({"input_tokens": 1, "output_tokens": 2}) == {
+        "usage": {
+            "prompt_tokens": 1,
+            "completion_tokens": 2,
+            "total_tokens": 3,
+        }
+    }
+
+
+def test_anthropic_streaming_response_usage():
+    start_usage = Usage(
+        input_tokens=11,
+        output_tokens=0,
+        cache_read_input_tokens=4,
+        cache_creation_input_tokens=2,
+    )
+    message = Message(
+        id="msg_1",
+        content=[],
+        model="claude-test",
+        role="assistant",
+        type="message",
+        usage=start_usage,
+    )
+    chunks = [
+        MessageStartEvent(type="message_start", message=message),
+        MessageDeltaEvent(
+            type="message_delta",
+            delta=Delta(stop_reason="end_turn", stop_sequence=None),
+            usage=MessageDeltaUsage(output_tokens=9),
+        ),
+    ]
+
+    usage = {}
+    for chunk in chunks:
+        usage = _update_stream_usage(chunk, usage)
+    assert usage == {
+        "input_tokens": 11,
+        "cache_read_input_tokens": 4,
+        "cache_creation_input_tokens": 2,
+        "output_tokens": 9,
+    }
+
+    response = _process_streamed_response(iter(chunks), [])
+    assert response.usage == {
+        "prompt_tokens": 11,
+        "completion_tokens": 9,
+        "total_tokens": 20,
+        "cache_read_input_tokens": 4,
+        "cache_creation_input_tokens": 2,
+    }
+
+
+def test_openai_streaming_response_usage():
+    chunks = [
+        SimpleNamespace(
+            choices=[SimpleNamespace(delta=SimpleNamespace(content="Hi"))],
+            usage=None,
+        ),
+        SimpleNamespace(
+            choices=[],
+            usage=SimpleNamespace(
+                prompt_tokens=3,
+                completion_tokens=1,
+                total_tokens=4,
+            ),
+        ),
+    ]
+    response = oai_process_streamed_response(iter(chunks), [], chat_model_used=True)
+    assert response.content == "Hi"
+    assert response.usage == {
+        "prompt_tokens": 3,
+        "completion_tokens": 1,
+        "total_tokens": 4,
+    }


### PR DESCRIPTION
Expose prompt/completion/total tokens in a unified usage dict for OpenAI, Google, and Anthropic streaming (and normalize non-streaming usage) so downstream logging can read response.usage consistently.