### PR TITLE
Fix: terminate the line of streamed LLM response

### DIFF
--- a/microcore/__init__.py
+++ b/microcore/__init__.py
@@ -241,4 +241,4 @@ __all__ = [
     # "wrappers",
 ]
 
-__version__ = "6.6.0"
+__version__ = "6.6.1"

--- a/microcore/logging.py
+++ b/microcore/logging.py
@@ -152,6 +152,21 @@ def _stream_log_response(out):
         LoggingConfig.OUTPUT_METHOD(out)
 
 
+def _stream_log_end(out=None):  # pylint: disable=unused-argument
+    """
+    Terminates the line of the streamed LLM response.
+
+    Streaming output is printed chunk by chunk without line breaks,
+    so the line needs to be closed when the response is complete.
+    """
+    global _is_new_request
+    if _is_new_request:
+        # No chunks were streamed, nothing was printed by _stream_log_response()
+        _is_new_request = False
+        return
+    LoggingConfig.OUTPUT_METHOD("\n")
+
+
 def _print_no_nln(s):
     print(s, end='', flush=True)
 
@@ -172,6 +187,8 @@ def use_logging(stream: bool = False):
             env().llm_before_handlers.append(_stream_log_request)
         if _stream_log_response not in config().CALLBACKS:
             env().config.CALLBACKS.append(_stream_log_response)
+        if _stream_log_end not in env().llm_after_handlers:
+            env().llm_after_handlers.append(_stream_log_end)
     else:
         if _log_request not in env().llm_before_handlers:
             env().llm_before_handlers.append(_log_request)
@@ -184,3 +201,5 @@ def use_logging(stream: bool = False):
             env().llm_before_handlers.remove(_stream_log_request)
         if _stream_log_response in config().CALLBACKS:
             config().CALLBACKS.remove(_stream_log_response)
+        if _stream_log_end in env().llm_after_handlers:
+            env().llm_after_handlers.remove(_stream_log_end)

--- a/tests/basic/test_logging.py
+++ b/tests/basic/test_logging.py
@@ -1,4 +1,5 @@
-from microcore import use_logging, env
+from microcore import use_logging, env, config
+from microcore.logging import _stream_log_end
 
 
 def test_logging():
@@ -9,4 +10,21 @@ def test_logging():
     assert 1 == len(env().llm_after_handlers)
     use_logging()
     assert 1 == len(env().llm_before_handlers)
+    assert 1 == len(env().llm_after_handlers)
+
+
+def test_stream_logging():
+    use_logging(stream=True)
+    assert 1 == len(env().llm_before_handlers)
+    assert 1 == len(config().CALLBACKS)
+    # closes the line of the streamed response
+    assert [_stream_log_end] == env().llm_after_handlers
+    use_logging(stream=True)
+    assert 1 == len(env().llm_before_handlers)
+    assert 1 == len(config().CALLBACKS)
+    assert [_stream_log_end] == env().llm_after_handlers
+    # switching back to non-streaming logging cleans it up
+    use_logging()
+    assert not config().CALLBACKS
+    assert _stream_log_end not in env().llm_after_handlers
     assert 1 == len(env().llm_after_handlers)


### PR DESCRIPTION
Closes #162

## Problem

`use_logging(stream=True)` prints the response chunk by chunk through `_print_no_nln()` and removes `_log_response()` from `llm_after_handlers` without registering a replacement, so the response line is never terminated and the next output is glued to its end.

## Fix

Register `_stream_log_end()` in `llm_after_handlers` in the `stream` branch of `use_logging()`, and remove it in the `else` branch — symmetric with how `_log_response()` is already handled. The newline goes through `LoggingConfig.OUTPUT_METHOD`, so custom output sinks still receive it.

If `_is_new_request` is still set when the response completes, no chunks ever reached `_stream_log_response()` (file cache hit, or a backend that did not stream), so nothing was printed and the handler stays silent instead of emitting a stray blank line.

Verified manually:

```
streamed     -> '\x1b[39mLLM Response:\x1b[36m\n    Hel\x1b[39m\x1b[36mlo\x1b[39m\n'
not streamed -> ''
```

## Notes

- Registration is idempotent across repeated `use_logging(stream=True)` calls; switching back to `use_logging()` cleans it up. Covered by the new `test_stream_logging`.
- Version bumped to 6.6.1.
- Consumers that call `env().llm_async_function` directly instead of `llm()` / `allm()` bypass `llm_after_handlers` entirely and are not affected by this fix — lm-proxy is one such case and needs its own newline handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
