### PR TITLE
Refresh provider model presets for 6.7.2

### DIFF
--- a/examples/ask_various_llms_via_mcp/ask_various_llms_mcp_server.py
+++ b/examples/ask_various_llms_via_mcp/ask_various_llms_mcp_server.py
@@ -8,8 +8,8 @@ configs = {  # See https://github.com/Nayjest/ai-microcore?tab=readme-ov-file#%E
         "api_key": os.getenv("OPENAI_API_KEY"),
         "api_base": "https://api.openai.com/v1",
     },
-    "grok-4.3": {
-        "model": "grok-4.3-latest",
+    "grok-4.6": {
+        "model": "grok-4.6",
         "api_type": mc.ApiType.OPENAI,
         "api_key": os.getenv("XAI_API_KEY"),
         "api_base": "https://api.x.ai/v1",

--- a/microcore/__init__.py
+++ b/microcore/__init__.py
@@ -241,4 +241,4 @@ __all__ = [
     # "wrappers",
 ]
 
-__version__ = "6.7.1"
+__version__ = "6.7.2"

--- a/microcore/llm_backends.py
+++ b/microcore/llm_backends.py
@@ -240,33 +240,33 @@ DEFAULT_PLATFORMS = {
 }
 
 HIGH_END_MODELS: dict[ApiPlatform, str] = {
-    ApiPlatform.OPENAI: "gpt-5.6",  # I/O: $5/$30 /M tokens
+    ApiPlatform.OPENAI: "gpt-5.6",  # I/O: $4/$20 /M tokens
     ApiPlatform.ANTHROPIC: "claude-fable-5",  # I/O: $10/$50 /M tokens
     ApiPlatform.GOOGLE_AI_STUDIO: "gemini-2.5-pro",
     ApiPlatform.GOOGLE_VERTEX_AI: "gemini-2.5-pro",
     ApiPlatform.MISTRAL: "mistral-large-latest",
-    ApiPlatform.XAI: "grok-4.3",  # I/O: $1.25 $2.50 /M tokens
+    ApiPlatform.XAI: "grok-4.6",  # I/O: $2/$6 /M tokens
     ApiPlatform.DEEPSEEK: "deepseek-v4-pro",
-    ApiPlatform.CEREBRAS: "gpt-oss-120b",  # I/O: $0.35/$0.75 /M tokens
+    ApiPlatform.CEREBRAS: "gpt-oss-120b",
     ApiPlatform.GROQ: "openai/gpt-oss-120b",  # I/O: $0.15/$0.60 /M tokens
-    ApiPlatform.FIREWORKS: "accounts/fireworks/models/kimi-k2-thinking",  # I/O: $0.60/$2.50 /M
+    ApiPlatform.FIREWORKS: "accounts/fireworks/models/kimi-k2p6",  # I/O: $0.95/$4 /M tokens
     ApiPlatform.PERPLEXITY: "sonar-deep-research",  # I/O: $2/$8 /M tokens
 }
 LOW_END_MODELS: dict[ApiPlatform, str] = {
     ApiPlatform.OPENAI: "gpt-5.6-luna",
     ApiPlatform.ANTHROPIC: "claude-haiku-4-5",  # I/O: $1/$5 /M tokens
-    ApiPlatform.GOOGLE_AI_STUDIO: "gemini-3.1-flash-lite",  # I/O: $0.25 $1.50 /M tokens
-    ApiPlatform.GOOGLE_VERTEX_AI: "gemini-3.1-flash-lite",
-    ApiPlatform.XAI: "grok-4-1-fast",  # I/O: $0.20 $0.50 /M tokens
+    ApiPlatform.GOOGLE_AI_STUDIO: "gemini-3.5-flash-lite",  # I/O: $0.30/$2.50 /M tokens
+    ApiPlatform.GOOGLE_VERTEX_AI: "gemini-3.5-flash-lite",
+    ApiPlatform.XAI: "grok-4.3",  # I/O: $1.25/$2.50 /M tokens
     ApiPlatform.MISTRAL: "ministral-3b-2512",
     ApiPlatform.DEEPSEEK: "deepseek-v4-flash",
-    ApiPlatform.CEREBRAS: "llama3.1-8b",  # I/O: $0.10/M tokens
-    ApiPlatform.GROQ: "llama-3.1-8b-instant",    # I/O: $0.05/$0.08 /M tokens
+    ApiPlatform.CEREBRAS: "gemma-4-31b",
+    ApiPlatform.GROQ: "openai/gpt-oss-20b",  # I/O: $0.075/$0.30 /M tokens
     ApiPlatform.FIREWORKS: "accounts/fireworks/models/gpt-oss-20b",  # I/O: $0.07 / $0.30 /M tokens
     ApiPlatform.PERPLEXITY: "sonar",  # I/O: $1/$1 /M tokens
 }
 MID_END_MODELS: dict[ApiPlatform, str] = {
-    ApiPlatform.ANTHROPIC: "claude-sonnet-5",  # I/O: $3/$15 /M tokens
+    ApiPlatform.ANTHROPIC: "claude-sonnet-5",  # I/O: $2/$10 /M tokens
     ApiPlatform.PERPLEXITY: "sonar-pro",  # I/O: $3/$15 /M tokens
     ApiPlatform.GOOGLE_AI_STUDIO: "gemini-3.5-flash",  # I/O: $1.5/$9 /M tokens
     ApiPlatform.GOOGLE_VERTEX_AI: "gemini-3.5-flash",


### PR DESCRIPTION
## Summary

Refresh default LLM model presets to current stable provider model IDs.

- Google: upgrade the Flash-Lite default to Gemini 3.5 Flash-Lite.
- xAI: use Grok 4.6 for high-end and Grok 4.3 for lower-cost requests.
- Cerebras: replace archived presets with GPT-OSS 120B and Gemma 4 31B.
- Groq: use GPT-OSS 120B and GPT-OSS 20B.
- Fireworks: use Kimi K2.6.
- Align price annotations and the multi-provider MCP example.
- Bump the package version to 6.7.2.

Mistral and Google Pro presets remain unchanged.

## Validation

- Focused model-backend and configuration tests: 10 passed.
- Lint and whitespace checks passed.
- Live smoke tests passed for each updated provider/model pair, including Gemini 3.5 Flash-Lite, Grok 4.6 and 4.3, Cerebras GPT-OSS 120B and Gemma 4 31B, Groq GPT-OSS 120B and 20B, and Fireworks Kimi K2.6.