### PR TITLE
Add inspect.software badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   <a href="https://app.codacy.com/gh/Nayjest/ai-microcore/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade" target="_blank"><img src="https://app.codacy.com/project/badge/Grade/441d03416bc048828c649129530dcbc3" alt="Code Quality"></a>
   <a href="https://github.com/Nayjest/ai-microcore/actions/workflows/pylint.yml" target="_blank"><img src="https://github.com/Nayjest/ai-microcore/actions/workflows/pylint.yml/badge.svg" alt="Pylint"></a>
   <a href="https://github.com/Nayjest/ai-microcore/actions/workflows/tests.yml" target="_blank"><img src="https://github.com/Nayjest/ai-microcore/actions/workflows/tests.yml/badge.svg" alt="Tests"></a>
+  <a href="https://inspect.software/software/nayjest/ai-microcore" target="_blank"><img src="https://raw.githubusercontent.com/inspect-software/badges/main/v1/n/Nayjest/ai-microcore.svg" alt="Software Health"></a>
   <img src="https://raw.githubusercontent.com/Nayjest/ai-microcore/coverage-badge/coverage.svg" alt="Code Coverage">
   <a href="https://github.com/vshymanskyy/StandWithUkraine/blob/main/README.md" target="_blank"><img src="https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/refs/heads/main/badges/StandWithUkraine.svg" alt="Stand With Ukraine"></a>
   <a href="https://github.com/Nayjest/ai-microcore/blob/main/LICENSE" target="_blank"><img src="https://img.shields.io/static/v1?label=license&message=MIT&color=d08aff" alt="License"></a>


### PR DESCRIPTION
Adds the native inspect.software health badge to the README badge row, linking to the repository's report page at https://inspect.software/software/nayjest/ai-microcore.